### PR TITLE
PopOS Pipewire Configuration

### DIFF
--- a/linux-popos/flatpak.packages
+++ b/linux-popos/flatpak.packages
@@ -9,3 +9,4 @@ net.cozic.joplin_desktop
 org.kde.krita
 org.keepassxc.KeePassXC
 org.signal.Signal
+com.github.wwmm.easyeffects

--- a/linux-popos/pipewire/LoudnessEqualiser.json
+++ b/linux-popos/pipewire/LoudnessEqualiser.json
@@ -1,0 +1,402 @@
+{
+    "output": {
+        "blocklist": [],
+        "compressor": {
+            "attack": 130,
+            "boost-amount": 6,
+            "boost-threshold": -60,
+            "hpf-frequency": 10,
+            "hpf-mode": "off",
+            "input-gain": 0,
+            "knee": -23.9,
+            "lpf-frequency": 20000,
+            "lpf-mode": "off",
+            "makeup": 0,
+            "mode": "Upward",
+            "output-gain": 0,
+            "ratio": 5,
+            "release": 600,
+            "release-threshold": -120,
+            "sidechain": {
+                "lookahead": 0,
+                "mode": "RMS",
+                "preamp": 0,
+                "reactivity": 10,
+                "source": "Middle",
+                "type": "Feed-forward"
+            },
+            "threshold": -10
+        },
+        "equalizer": {
+            "input-gain": 0,
+            "left": {
+                "band0": {
+                    "frequency": 32,
+                    "gain": 3.5,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band1": {
+                    "frequency": 64,
+                    "gain": 2,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band2": {
+                    "frequency": 128,
+                    "gain": 1,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band3": {
+                    "frequency": 256,
+                    "gain": 0,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band4": {
+                    "frequency": 512,
+                    "gain": -0.5,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band5": {
+                    "frequency": 1024,
+                    "gain": -1.5,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band6": {
+                    "frequency": 2048,
+                    "gain": -0.25,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band7": {
+                    "frequency": 4096,
+                    "gain": 1.25,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band8": {
+                    "frequency": 8192,
+                    "gain": 2.75,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band9": {
+                    "frequency": 16384,
+                    "gain": 3,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                }
+            },
+            "mode": "IIR",
+            "num-bands": 10,
+            "output-gain": 0,
+            "right": {
+                "band0": {
+                    "frequency": 32,
+                    "gain": 3.5,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band1": {
+                    "frequency": 64,
+                    "gain": 2,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band2": {
+                    "frequency": 128,
+                    "gain": 1,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band3": {
+                    "frequency": 256,
+                    "gain": 0,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band4": {
+                    "frequency": 512,
+                    "gain": -0.5,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band5": {
+                    "frequency": 1024,
+                    "gain": -1.5,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band6": {
+                    "frequency": 2048,
+                    "gain": -0.25,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band7": {
+                    "frequency": 4096,
+                    "gain": 1.25,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band8": {
+                    "frequency": 8192,
+                    "gain": 2.75,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                },
+                "band9": {
+                    "frequency": 16384,
+                    "gain": 3,
+                    "mode": "RLC (BT)",
+                    "mute": false,
+                    "q": 1.6,
+                    "slope": "x1",
+                    "solo": false,
+                    "type": "Bell"
+                }
+            },
+            "split-channels": false
+        },
+        "gate": {
+            "attack": 2000,
+            "detection": "Peak",
+            "input-gain": 0,
+            "knee": 18,
+            "makeup": 0,
+            "output-gain": 0,
+            "range": -30,
+            "ratio": 2,
+            "release": 2000,
+            "stereo-link": "Average",
+            "threshold": -50
+        },
+        "limiter": {
+            "alr": false,
+            "attack": 5,
+            "dithering": "None",
+            "external-sidechain": false,
+            "gain-boost": false,
+            "input-gain": 0,
+            "lookahead": 5,
+            "mode": "Herm Thin",
+            "output-gain": 0,
+            "oversampling": "Half x4(3L)",
+            "release": 10,
+            "sidechain-preamp": 0,
+            "stereo-link": 100,
+            "threshold": -1
+        },
+        "multiband_compressor": {
+            "band0": {
+                "attack-threshold": -30,
+                "attack-time": 50,
+                "boost-amount": 6,
+                "boost-threshold": -72,
+                "compression-mode": "Downward",
+                "compressor-enable": true,
+                "external-sidechain": false,
+                "knee": -24,
+                "makeup": 0,
+                "mute": false,
+                "ratio": 1.7,
+                "release-threshold": -120,
+                "release-time": 600,
+                "sidechain-custom-highcut-filter": false,
+                "sidechain-custom-lowcut-filter": false,
+                "sidechain-highcut-frequency": 250,
+                "sidechain-lookahead": 0,
+                "sidechain-lowcut-frequency": 10,
+                "sidechain-mode": "RMS",
+                "sidechain-preamp": 0,
+                "sidechain-reactivity": 10,
+                "sidechain-source": "Middle",
+                "solo": false
+            },
+            "band1": {
+                "attack-threshold": -30,
+                "attack-time": 30,
+                "boost-amount": 6,
+                "boost-threshold": -72,
+                "compression-mode": "Downward",
+                "compressor-enable": true,
+                "enable-band": true,
+                "external-sidechain": false,
+                "knee": -24,
+                "makeup": 0,
+                "mute": false,
+                "ratio": 1.7,
+                "release-threshold": -120,
+                "release-time": 450,
+                "sidechain-custom-highcut-filter": false,
+                "sidechain-custom-lowcut-filter": false,
+                "sidechain-highcut-frequency": 1250,
+                "sidechain-lookahead": 0,
+                "sidechain-lowcut-frequency": 250,
+                "sidechain-mode": "RMS",
+                "sidechain-preamp": 0,
+                "sidechain-reactivity": 10,
+                "sidechain-source": "Middle",
+                "solo": false,
+                "split-frequency": 250
+            },
+            "band2": {
+                "attack-threshold": -30,
+                "attack-time": 10,
+                "boost-amount": 6,
+                "boost-threshold": -72,
+                "compression-mode": "Downward",
+                "compressor-enable": true,
+                "enable-band": true,
+                "external-sidechain": false,
+                "knee": -24,
+                "makeup": 0,
+                "mute": false,
+                "ratio": 1.7,
+                "release-threshold": -120,
+                "release-time": 250,
+                "sidechain-custom-highcut-filter": false,
+                "sidechain-custom-lowcut-filter": false,
+                "sidechain-highcut-frequency": 5000,
+                "sidechain-lookahead": 0,
+                "sidechain-lowcut-frequency": 1250,
+                "sidechain-mode": "RMS",
+                "sidechain-preamp": 0,
+                "sidechain-reactivity": 10,
+                "sidechain-source": "Middle",
+                "solo": false,
+                "split-frequency": 1250
+            },
+            "band3": {
+                "attack-threshold": -30,
+                "attack-time": 5,
+                "boost-amount": 6,
+                "boost-threshold": -72,
+                "compression-mode": "Downward",
+                "compressor-enable": true,
+                "enable-band": true,
+                "external-sidechain": false,
+                "knee": -24,
+                "makeup": 0,
+                "mute": false,
+                "ratio": 1.7,
+                "release-threshold": -120,
+                "release-time": 100,
+                "sidechain-custom-highcut-filter": false,
+                "sidechain-custom-lowcut-filter": false,
+                "sidechain-highcut-frequency": 20000,
+                "sidechain-lookahead": 0,
+                "sidechain-lowcut-frequency": 5000,
+                "sidechain-mode": "RMS",
+                "sidechain-preamp": 0,
+                "sidechain-reactivity": 10,
+                "sidechain-source": "Middle",
+                "solo": false,
+                "split-frequency": 5000
+            },
+            "band4": {
+                "enable-band": false
+            },
+            "band5": {
+                "enable-band": false
+            },
+            "band6": {
+                "enable-band": false
+            },
+            "band7": {
+                "enable-band": false
+            },
+            "compressor-mode": "Modern",
+            "envelope-boost": "None",
+            "input-gain": 0,
+            "output-gain": 0
+        },
+        "plugins_order": [
+            "gate",
+            "compressor",
+            "multiband_compressor",
+            "equalizer",
+            "limiter"
+        ]
+    }
+}

--- a/linux-popos/pipewire/README.md
+++ b/linux-popos/pipewire/README.md
@@ -1,0 +1,8 @@
+# PopOS PipeWire Loudness Normalisation
+
+This directory contains the PipeWire configuration to normalise the audio for PopOS.
+
+It heavily leverages the excellent work by [Guisy Digital](https://github.com/Digitalone1) who has the amazing [EasyEffects Presets](https://github.com/Digitalone1/EasyEffects-Presets) for Loudness Equalization.
+
+* [setup-loudness-equalisation.sh](setup-loudness-equalisation.sh) - installs the above preset to an Installation of [EasyEffects](https://flathub.org/apps/details/com.github.wwmm.easyeffects) output folder.
+* [LoudnessEqualiser.json](LoudnessEqualiser.json) - my customised version.

--- a/linux-popos/pipewire/setup-loudness-equalisation.sh
+++ b/linux-popos/pipewire/setup-loudness-equalisation.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/../../scripts/console-colours.sh"
+
+GIT_REPOSITORY="https://raw.githubusercontent.com/Digitalone1/EasyEffects-Presets/master/"
+PRESET="LoudnessEqualizer.json"
+
+check_installation() {
+    if command -v flatpak &> /dev/null && flatpak list | grep -q "com.github.wwmm.easyeffects"; then
+        PRESETS_DIRECTORY="$HOME/.var/app/com.github.wwmm.easyeffects/config/easyeffects"
+    elif which easyeffects >/dev/null; then
+        PRESETS_DIRECTORY="$HOME/.config/easyeffects"
+    else
+        die "Couldn't determine EasyEffects Presets folder."
+    fi
+    mkdir -p $PRESETS_DIRECTORY
+}
+
+install_preset() {
+    PRESET_LOCATION="$PRESETS_DIRECTORY/output/$PRESET"
+    curl "$GIT_REPOSITORY/$PRESET" --output $PRESET_LOCATION --silent
+}
+
+verify_install() {
+    [ ! -f "$PRESET_LOCATION" ] && die "Installation failed to find preset in ('$PRESET_LOCATION') :("
+}
+
+show_info "Checking installation..."
+check_installation
+show_info "Installing Preset ('$PRESET')..."
+install_preset
+verify_install
+show_success "Installing Preset ('$PRESET')...Done!"


### PR DESCRIPTION
Adds setup for Pipewire loudness normalisation.

- Adds EasyEffects to Flatpak default install
- Adds setup script to copy script from Digitalone1's repo.
- Adds README.

